### PR TITLE
enable Memcached storage nginx pagespeed

### DIFF
--- a/rpm_buildtree/nginx-pkg-64/etc/nginx/conf.d/pagespeed.conf
+++ b/rpm_buildtree/nginx-pkg-64/etc/nginx/conf.d/pagespeed.conf
@@ -1,5 +1,16 @@
 pagespeed On;
+
+# enable Memcached storage for cachefiles so inodes wont eaten up
+pagespeed MemcachedThreads 1;
+pagespeed MemcachedServers "localhost:11211";
+
+# must be there
 pagespeed FileCachePath "/var/cache/nginx/ngx_pagespeed/";
+
+# enable core filters
+pagespeed RewriteLevel CoreFilters;
+pagespeed EnableFilters collapse_whitespace,remove_comments;
+
 # Ensure requests for pagespeed optimized resources go to the pagespeed handler
 # and no extraneous headers get set.
 location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+" {


### PR DESCRIPTION
fix for eating up inodes in pagespeed config on large hosts
please ensure memcached is installed (yum install memcached) and it is set to a higher level of ram. (check ram and eg use a /8 fragment of ram e.g.

nano /etc/sysconfig/memcached

PORT="11211"
USER="memcached"
MAXCONN="2048"
CACHESIZE="4096"  <<<--- need to set for your needs
OPTIONS=""

and then 
service memcached restart

(on existing installs of ndeploy nginx just change the configs and install/edit memcache and restart nginx.
